### PR TITLE
Documentation Typo

### DIFF
--- a/data/articles/html/360047039292-Step-that-triggers-pipeline-in-different-project_en-us.html
+++ b/data/articles/html/360047039292-Step-that-triggers-pipeline-in-different-project_en-us.html
@@ -6,5 +6,5 @@
   command: |
     curl --location --request POST 'https://circleci.com/api/v2/project/(vcs)/(org)/(project)/pipeline' \
     --header 'Content-Type: application/json' \
-    -u "${API_TOKEN}:"</pre>
+    -u "${API_TOKEN}"</pre>
 <p>In the above snippet, you will need to update <code>(vcs)</code> to <code>github</code> or <code>bitbucket</code>, <code>(org)</code> to your Organization, and <code>(project)</code> to the name of your project.</p>


### PR DESCRIPTION
I think there is a type in bash line 8 `${API_TOKEN}:`. It should be `${API_TOKEN}`