### PR TITLE
Update 360021624194-Test-summary-troubleshooting_en-us.html

### DIFF
--- a/data/articles/html/360021624194-Test-summary-troubleshooting_en-us.html
+++ b/data/articles/html/360021624194-Test-summary-troubleshooting_en-us.html
@@ -10,5 +10,7 @@
 <p> </p>
 <h2>Test files cannot be larger than 15MB</h2>
 <p>Test files larger than 15MB will fail to upload, though it will not show this failure in the UI. It fails silently in the background. </p>
+<h2>Golang</h2>
+<p>Make sure that your test command contains `-v` argument (e.g. `go test -v ./...`) otherwise no test results will be shown. </p>
 <p> </p>
 <p> </p>


### PR DESCRIPTION
Add gotcha about golang test results not showing up unless `-v` argument is used.