### PR TITLE
Cleanup VPN Example Code

### DIFF
--- a/data/articles/html/360049397051-How-to-set-up-a-VPN-connection-during-builds_en-us.html
+++ b/data/articles/html/360049397051-How-to-set-up-a-VPN-connection-during-builds_en-us.html
@@ -30,7 +30,7 @@
 <ul>
     <li><span>Base64-encode the OpenVPN client configuration file, and store it as an <a href="https://circleci.com/docs/2.0/env-vars/" target="_blank" rel="noopener">environment variable</a>.</span></li>
     <li>
-        <span>If the VPN client authentication is credentials-based (user-locked profile), you'll also need to add the username and password as environment variables (<code>VPN_USER</code> and <code>VPN_PASSWORD</code>).</span><span><span><span><br></span></span></span><span><span><span></span></span></span>
+        <span>If the VPN client authentication is credentials-based (user-locked profile), you'll also need to add the username and password as environment variables (<code>VPN_USER</code> and <code>VPN_PASSWORD</code>).</span>
     </li>
 </ul>
 <pre style="background-color: #f3f3f3;">version: 2.1
@@ -47,7 +47,8 @@ jobs:
           name: Install OpenVPN
           command: |
             sudo apt-get update
-            sudo apt-get install openvpn -y<br>
+            sudo apt-get install -y openvpn
+
       - run:
           name: Check IP before VPN connection
           command: |
@@ -55,29 +56,62 @@ jobs:
             route -n
             sudo netstat -anp
             cat /etc/resolv.conf
-            echo "Public IP before VPN connection is $(curl checkip.amazonaws.com)"<br>
+            echo "Public IP before VPN connection is $(curl -s https://checkip.amazonaws.com/)"
+
       - run:
           name: VPN Setup
           background: true
           command: |
-            echo $VPN_CLIENT_CONFIG | base64 --decode &gt; /tmp/config.ovpn<br><br>            if grep auth-user-pass /tmp/config.ovpn; then<br>              if [ -z "${VPN_USER:-}" ] || [ -z "${VPN_PASSWORD:-}" ]; then<br>                echo "Your VPN client is configured with a user-locked profile. Make sure to set the VPN_USER and VPN_PASSWORD environment variables"<br>                exit 1<br>              else<br>                printf "$VPN_USER\\n$VPN_PASSWORD" &gt; /tmp/vpn.login<br>              fi<br>            fi<br><br>            #IMPORTANT: Include the following line and the `--route` options to exclude the connection from CircleCI and the link-local range<br>            phone_home="$(netstat -an | grep ':22 .*ESTABLISHED' | head -n1 | awk '{ split($5, a, ":"); print a[1] }')"<br>            echo $phone_home<br><br>            if grep auth-user-pass /tmp/config.ovpn; then
+            echo $VPN_CLIENT_CONFIG | base64 --decode &gt; /tmp/config.OpenVPN
+            if grep auth-user-pass /tmp/config.ovpn; then
+              if [ -z "${VPN_USER:-}" ] || [ -z "${VPN_PASSWORD:-}" ]; then
+                echo "Your VPN client is configured with a user-locked profile. Make sure to set the VPN_USER and VPN_PASSWORD environment variables"
+                exit 1
+              else
+                printf "$VPN_USER\\n$VPN_PASSWORD" &gt; /tmp/vpn.login
+              fi
+            fi
+
+            #IMPORTANT: Include the following line and the `--route` options to exclude the connection from CircleCI and the link-local range
+            phone_home="$(netstat -an | grep ':22 .*ESTABLISHED' | head -n1 | awk '{ split($5, a, ":"); print a[1] }')"
+            echo $phone_home
+
+            if grep auth-user-pass /tmp/config.ovpn; then
               sudo openvpn --config /tmp/config.ovpn --auth-user-pass /tmp/vpn.login \
                 --route $phone_home 255.255.255.255 net_gateway \
-                --route 169.254.0.0 255.255.0.0 net_gateway &gt; /tmp/openvpn.log<br>            else<br>              sudo openvpn --config /tmp/config.ovpn \<br>                --route $phone_home 255.255.255.255 net_gateway \<br>                --route 169.254.0.0 255.255.0.0 net_gateway &gt; /tmp/openvpn.log<br>            fi<br>
+                --route 169.254.0.0 255.255.0.0 net_gateway &gt; /tmp/openvpn.log
+            else
+              sudo openvpn --config /tmp/config.ovpn \
+                --route $phone_home 255.255.255.255 net_gateway \
+                --route 169.254.0.0 255.255.0.0 net_gateway &gt; /tmp/openvpn.log
+            fi
+
       - run:
-          name: Wait for the connection to be established and check<br>          command: |<br>            while [ $(cat /tmp/openvpn.log|grep -c "<span>Initialization Sequence Completed</span>") == 0 ]; do<br>              echo "Attempting to connect..."<br>              sleep 1;<br>            done<br>            echo "VPN Connected"<br>            echo "Public IP is now $(curl checkip.amazonaws.com)"
+          name: Wait for VPN connection to be established
+          command: |
+            while ! grep "Initialization Sequence Completed" /tmp/openvpn.log; do
+              echo "Waiting for connection..."
+              sleep 1
+            done
+            echo "VPN Connected"
+            echo "Public IP is now $(curl -s https://checkip.amazonaws.com/)"
 
       - run:
           name: Run commands in our infrastructure
           command: |
             # A command
-            # Another command<br><br>      - run:<br>          name: Disconnect from OpenVPN<br>          command: sudo killall openvpn || true<br>          when: always
+            # Another command
+
+      - run:
+          name: Disconnect from OpenVPN
+          command: sudo killall openvpn || true
+          when: always
 </pre>
-<p> </p>
+<p> </p>
 <h4 id="h_01F3TBTKPEDA8RBAQCVVZNG0T6"><strong>OpenVPN Connect (OpenVPN 3)</strong></h4>
 <ul>
     <li>
-        <span>Base64-encode the OpenVPN client configuration file, and store it as an <a href="https://circleci.com/docs/2.0/env-vars/" target="_blank" rel="noopener">environment variable</a>.</span><span><span><span><br></span></span></span><span><span><span></span></span></span>
+        <span>Base64-encode the OpenVPN client configuration file, and store it as an <a href="https://circleci.com/docs/2.0/env-vars/" target="_blank" rel="noopener">environment variable</a>.</span>
     </li>
     <li><span>With OpenVPN 3 Linux, storing user credentials in a text-based file to use when starting a VPN connection is <strong>unsupported</strong>. Please refer to <a href="https://openvpn.net/openvpn-3-linux-and-auth-user-pass/" target="_blank" rel="noopener">this documentation (OpenVPN 3 Linux and --auth-user-pass)</a> to set up a workaround.</span></li>
 </ul>
@@ -94,34 +128,65 @@ jobs:
       - run:
           name: Install OpenVPN
           command: |
-            sudo apt update &amp;&amp; sudo apt install apt-transport-https<br>            sudo wget https://swupdate.openvpn.net/repos/openvpn-repo-pkg-key.pub<br>            sudo apt-key add openvpn-repo-pkg-key.pub<br>            sudo wget -O /etc/apt/sources.list.d/openvpn3.list https://swupdate.openvpn.net/community/openvpn3/repos/openvpn3-xenial.list<br>            sudo apt update &amp;&amp; sudo apt install openvpn3<br>
+            sudo apt-get update &amp;&amp; sudo apt-get install -y apt-transport-https
+            curl -sL https://swupdate.openvpn.net/repos/openvpn-repo-pkg-key.pub | sudo apt-key add -
+            sudo curl -sLo /etc/apt/sources.list.d/openvpn3.list https://swupdate.openvpn.net/community/openvpn3/repos/openvpn3-xenial.list
+            sudo apt-get update &amp;&amp; sudo apt-get install -y openvpn3
+
       - run:
           name: Check IP before VPN connection
           command: |
-            echo "Public IP before VPN connection is $(curl checkip.amazonaws.com)"<br>
+            echo "Public IP before VPN connection is $(curl -s https://checkip.amazonaws.com/)"
+
       - run:
           name: VPN Setup
           background: true
           command: |
             echo $VPN_CLIENT_CONFIG | base64 --decode &gt; /tmp/config.ovpn
-<br>            #IMPORTANT: Include the following 3 lines to <span>exclude the link-local range</span><br>            phone_home="$(netstat -an | grep ':22 .*ESTABLISHED' | head -n1 | awk '{ split($5, a, ":"); print a[1] }')"<br>            echo $phone_home
-            echo -e "\nroute $phone_home 255.255.255.255 net_gateway" &gt;&gt; /tmp/config.ovpn<br>            echo "route 169.254.0.0 255.255.0.0 net_gateway" &gt;&gt; /tmp/config.ovpn<br>            <br>            #This will start the connection<br>            sudo openvpn3 session-start --config /tmp/config.ovpn &gt; /tmp/openvpn.log<br>
+
+            #IMPORTANT: Include the following 3 lines to exclude the link-local range
+            phone_home="$(netstat -an | grep ':22 .*ESTABLISHED' | head -n1 | awk '{ split($5, a, ":"); print a[1] }')"
+            echo $phone_home
+            echo -e "\nroute $phone_home 255.255.255.255 net_gateway" &gt;&gt; /tmp/config.ovpn
+            echo "route 169.254.0.0 255.255.0.0 net_gateway" &gt;&gt; /tmp/config.ovpn
+
+            #This will start the connection
+            sudo openvpn3 session-start --config /tmp/config.ovpn &gt; /tmp/openvpn.log
+
       - run:
-          name: Wait for the connection to be established and check<br>          command: |<br>            while [ $(sudo openvpn3 sessions-list|grep -c "Client connected") == 0 ]; do<br>              echo "Attempting to connect..."<br>              sleep 1;<br>            done<br>            echo "VPN Connected"<br>            <br>            sudo openvpn3 sessions-list<br>            echo "Public IP is now $(curl checkip.amazonaws.com)"<br>
+          name: Wait for VPN connection to be established
+          command: |
+            while ! sudo openvpn3 sessions-list | grep "Client connected"; do
+              echo "Waiting for connection..."
+              sleep 1
+            done
+            echo "VPN Connected"
+
+            sudo openvpn3 sessions-list
+            echo "Public IP is now $(curl -s https://checkip.amazonaws.com/)"
+
       - run:
           name: Run commands in our infrastructure
           command: |
             # A command
-            # Another command<br><br>      - run:<br>          name: Disconnect from OpenVPN<br>          command: |<br>            SESSION_PATH=$(sudo openvpn3 sessions-list | grep Path | awk -F': ' '{print $2}')<br>            echo $SESSION_PATH<br>            sudo openvpn3 session-manage --session-path $SESSION_PATH --disconnect<br>          when: always
+            # Another command
+
+      - run:
+          name: Disconnect from OpenVPN
+          command: |
+            SESSION_PATH=$(sudo openvpn3 sessions-list | awk -F': ' '/Path/ { print $2 }')
+            echo $SESSION_PATH
+            sudo openvpn3 session-manage --session-path $SESSION_PATH --disconnect
+            when: always
 </pre>
 <p> </p>
 <h4 id="l2tp"><strong>L2TP</strong></h4>
-<p><span><span>To set up an L2TP VPN connection, we recommend referring to <a href="https://github.com/hwdsl2/setup-ipsec-vpn/blob/master/docs/clients.md#configure-linux-vpn-clients-using-the-command-line" target="_blank" rel="noopener">this guide.</a></span></span><span><span></span></span></p>
-<p><span><span>We suggest storing <code>VPN_SERVER_IP</code>, <code>VPN_IPSEC_PSK</code>, <code>VPN_USER</code> and <code>VPN_PASSWORD</code> as <a href="https://circleci.com/docs/2.0/env-vars/" rel="noreferrer">environment variables</a>. Ideally, you might want to base64-encode <code>VPN_IPSEC_PSK</code> before storing it; you'll need to decode it during the build.</span></span></p>
+<p><span>To set up an L2TP VPN connection, we recommend referring to <a href="https://github.com/hwdsl2/setup-ipsec-vpn/blob/master/docs/clients.md#configure-linux-vpn-clients-using-the-command-line" target="_blank" rel="noopener">this guide.</a></span></p>
+<p><span>We suggest storing <code>VPN_SERVER_IP</code>, <code>VPN_IPSEC_PSK</code>, <code>VPN_USER</code> and <code>VPN_PASSWORD</code> as <a href="https://circleci.com/docs/2.0/env-vars/" rel="noreferrer">environment variables</a>. Ideally, you might want to base64-encode <code>VPN_IPSEC_PSK</code> before storing it; you'll need to decode it during the build.</span></p>
 <p dir="auto">To retrieve the default gateway IP address during the build, you can use either of the following:</p>
 <ul dir="auto" type="disc">
-    <li type="disc"><code>default_gw_IP=$(netstat -r | grep default | awk '{ print $2 }')</code></li>
-    <li type="disc"><code>default_gw_IP=$(ip route | grep default | awk '{ print $3 }')</code></li>
+    <li type="disc"><code>default_gw_IP=$(netstat -r | awk '/default/ { print $2 }')</code></li>
+    <li type="disc"><code>default_gw_IP=$(ip route | awk '/default/ { print $3 }')</code></li>
 </ul>
 <p> </p>
 <h2 id="h_01F3THFMEAY31K30ZKP3M0RVZ7">
@@ -129,7 +194,7 @@ jobs:
 </h2>
 <ul>
     <li>
-        <span>Base64-encode the OpenVPN client configuration file, and store it as an <a href="https://circleci.com/docs/2.0/env-vars/" target="_blank" rel="noopener">environment variable</a>.</span><span><span><span><br></span></span></span><span><span><span></span></span></span>
+        <span>Base64-encode the OpenVPN client configuration file, and store it as an <a href="https://circleci.com/docs/2.0/env-vars/" target="_blank" rel="noopener">environment variable</a>.</span>
     </li>
     <li><span>If the VPN client authentication is credentials-based (user-locked profile), you'll also need to add the username and password as environment variables (<code>VPN_USER</code> and <code>VPN_PASSWORD</code>).</span></li>
 </ul>
@@ -140,46 +205,115 @@ workflows:
       - build
 jobs:
   build:
-    macos:<br>      xcode: "12.2.0"
+    macos:
+      xcode: "12.2.0"
     steps:
       - run:
           name: Install OpenVPN
           command: |
-            <span>brew install openvpn</span><br>
+            <span>brew install openvpn</span>
+
       - run:
           name: Check IP before VPN connection
           command: |
             ifconfig
-            echo "Public IP before VPN connection is $(curl checkip.amazonaws.com)"<br>
+            echo "Public IP before VPN connection is $(curl checkip.amazonaws.com)"
+
       - run:
           name: VPN Setup
           command: |
-            <span>echo $VPN_CLIENT_CONFIG | base64 --decode | tee /tmp/config.ovpn 1&gt;/dev/null</span><br>           <span> <br>            if grep auth-user-pass /tmp/config.ovpn; then<br>              if [ -z "${VPN_USER:-}" ] || [ -z "${VPN_PASSWORD:-}" ]; then<br>                echo "Your VPN client is configured with a user-locked profile. Make sure to set the VPN_USER and VPN_PASSWORD environment variables"<br>                exit 1<br>              else<br>                printf "$VPN_USER\\n$VPN_PASSWORD" &gt; /tmp/vpn.login<br>                sed -i config.bak 's|^auth-user-pass.*|auth-user-pass /tmp/vpn\.login|' /tmp/config.ovpn<br>              fi<br>            fi<br><br>            touch /tmp/openvpn.log</span>
-<br>            #IMPORTANT: Include the following 3 lines to <span>exclude the link-local range</span><br>            <span>phone_home="$(netstat -an | grep '\.2222\s.*ESTABLISHED' | head -n1 | awk '{ split($5, a, "."); print a[1] "." a[2] "." a[3] "." a[4] }')"<br></span>            echo $phone_home
-            echo -e "\nroute $phone_home 255.255.255.255 net_gateway" | tee -a /tmp/config.ovpn<br>            echo "route 169.254.0.0 255.255.0.0 net_gateway" | tee -a /tmp/config.ovpn<br>            <br>            cat \&lt;&lt; EOF | sudo tee /Library/LaunchDaemons/org.openvpn.plist 1&gt;/dev/null<br>            &lt;?xml version="1.0" encoding="UTF-8"?&gt;<br>            &lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;<br>            &lt;plist version="1.0"&gt;<br>            &lt;dict&gt; <br>                &lt;key&gt;Label&lt;/key&gt;<br>                &lt;string&gt;org.openvpn&lt;/string&gt;<br>                &lt;key&gt;Program&lt;/key&gt;<br>                  &lt;string&gt;/usr/local/sbin/openvpn&lt;/string&gt;<br>                &lt;key&gt;ProgramArguments&lt;/key&gt;<br>                  &lt;array&gt;<br>                    &lt;string&gt;--config&lt;/string&gt;<br>                    &lt;string&gt;/tmp/config.ovpn&lt;/string&gt;<br>                  &lt;/array&gt;<br>                &lt;key&gt;RunAtLoad&lt;/key&gt;<br>                  &lt;false/&gt;<br>                &lt;key&gt;TimeOut&lt;/key&gt;<br>                  &lt;integer&gt;90&lt;/integer&gt;<br>                &lt;key&gt;StandardErrorPath&lt;/key&gt;<br>                  &lt;string&gt;/tmp/openvpn.log&lt;/string&gt;<br>                &lt;key&gt;StandardOutPath&lt;/key&gt;<br>                  &lt;string&gt;/tmp/openvpn.log&lt;/string&gt;<br>                &lt;key&gt;KeepAlive&lt;/key&gt;<br>                 &lt;true/&gt;<br>              &lt;/dict&gt;<br>              &lt;/plist&gt;<br>              EOF<br>              ifconfig<br>              echo "Public IP before VPN connection is &gt; $(curl <a href="http://checkip.amazonaws.com)%22">http://checkip.amazonaws.com)"</a><br><br>              #This will start the connection<br>              sudo launchctl load /Library/LaunchDaemons/org.openvpn.plist<br>              sudo launchctl start org.openvpn<br>
+            echo $VPN_CLIENT_CONFIG | base64 --decode &gt; /tmp/config.ovpn
+
+            if grep auth-user-pass /tmp/config.ovpn; then
+              if [ -z "${VPN_USER:-}" ] || [ -z "${VPN_PASSWORD:-}" ]; then
+                echo "Your VPN client is configured with a user-locked profile. Make sure to set the VPN_USER and VPN_PASSWORD environment variables"
+                exit 1
+              else
+                printf "$VPN_USER\\n$VPN_PASSWORD" &gt; /tmp/vpn.login
+                sed -i config.bak 's|^auth-user-pass.*|auth-user-pass /tmp/vpn\.login|' /tmp/config.ovpn
+              fi
+            fi
+
+            touch /tmp/openvpn.log
+
+            #IMPORTANT: Include the following 3 lines to exclude the link-local range
+            phone_home="$(netstat -an | grep '\.2222\s.*ESTABLISHED' | head -n1 | awk '{ split($5, a, "."); print a[1] "." a[2] "." a[3] "." a[4] }')"
+            echo $phone_home
+            echo -e "\nroute $phone_home 255.255.255.255 net_gateway" | tee -a /tmp/config.ovpn
+            echo "route 169.254.0.0 255.255.0.0 net_gateway" | tee -a /tmp/config.ovpn
+
+            cat \&lt;&lt; EOF | sudo tee /Library/LaunchDaemons/org.openvpn.plist 1&gt;/dev/null
+            &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+            &lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
+            &lt;plist version="1.0"&gt;
+            &lt;dict&gt;
+                &lt;key&gt;Label&lt;/key&gt;
+                &lt;string&gt;org.openvpn&lt;/string&gt;
+                &lt;key&gt;Program&lt;/key&gt;
+                  &lt;string&gt;/usr/local/sbin/openvpn&lt;/string&gt;
+                &lt;key&gt;ProgramArguments&lt;/key&gt;
+                  &lt;array&gt;
+                    &lt;string&gt;--config&lt;/string&gt;
+                    &lt;string&gt;/tmp/config.ovpn&lt;/string&gt;
+                  &lt;/array&gt;
+                &lt;key&gt;RunAtLoad&lt;/key&gt;
+                  &lt;false/&gt;
+                &lt;key&gt;TimeOut&lt;/key&gt;
+                  &lt;integer&gt;90&lt;/integer&gt;
+                &lt;key&gt;StandardErrorPath&lt;/key&gt;
+                  &lt;string&gt;/tmp/openvpn.log&lt;/string&gt;
+                &lt;key&gt;StandardOutPath&lt;/key&gt;
+                  &lt;string&gt;/tmp/openvpn.log&lt;/string&gt;
+                &lt;key&gt;KeepAlive&lt;/key&gt;
+                 &lt;true/&gt;
+              &lt;/dict&gt;
+              &lt;/plist&gt;
+              EOF
+              ifconfig
+              echo "Public IP before VPN connection is $(curl -s https://checkip.amazonaws.com/)"
+
+              #This will start the connection
+              sudo launchctl load /Library/LaunchDaemons/org.openvpn.plist
+              sudo launchctl start org.openvpn
+
       - run:
-          name: Wait for the connection to be established and check<br>          command: |<br>            while [ $(cat /tmp/openvpn.log|grep -c "<span>Initialization Sequence Completed</span>") == 0 ]; do<br>              echo "Attempting to connect..."<br>              sleep 1;<br>            done<br>            echo "VPN Connected"<br>         <br>            sudo launchctl list | grep openvpn<br>            echo "Public IP is now $(curl checkip.amazonaws.com)"<br>
+          name: Wait for VPN connection to be established
+          command: |
+            while ! grep "Initialization Sequence Completed" /tmp/openvpn.log; do
+              echo "Waiting for connection..."
+              sleep 1
+            done
+            echo "VPN Connected"
+
+            sudo launchctl list | grep openvpn
+            echo "Public IP is now $(curl -s https://checkip.amazonaws.com/)"
+
       - run:
           name: Run commands in our infrastructure
           command: |
             # A command
-            # Another command<br><br>      - run:<br>          name: Disconnect from OpenVPN<br>          command: <span>sudo launchctl stop org.openvpn</span><br>          when: always
+            # Another command
+
+        - run:
+          name: Disconnect from OpenVPN
+          command: sudo launchctl stop org.openvpn
+          when: always
 </pre>
-<p><strong> </strong></p>
+<p> </p>
 <h2 id="h_01F7XH9G40MXW14H2GFHRD8XXJ">
     <code>windows</code> executor (<a href="https://circleci.com/docs/2.0/hello-world-windows/#windows-executor-images" target="_blank" rel="noopener">Windows executor images</a>)
 </h2>
 <ul>
     <li><span>Base64-encode the OpenVPN client configuration file, and store it as an <a href="https://circleci.com/docs/2.0/env-vars/" target="_blank" rel="noopener">environment variable</a>.</span></li>
     <li>
-        <span>If the VPN client authentication is credentials-based (user-locked profile), you'll also need to add the username and password as environment variables (<code>VPN_USER</code> and <code>VPN_PASSWORD</code>).</span><span><span><span><br></span></span></span><span><span><span></span></span></span>
+        <span>If the VPN client authentication is credentials-based (user-locked profile), you'll also need to add the username and password as environment variables (<code>VPN_USER</code> and <code>VPN_PASSWORD</code>).</span>
     </li>
 </ul>
 <pre style="background-color: #f3f3f3;">version: 2.1
 
 orbs:
   win: circleci/windows@2.2.0
-  
+
 workflows:
   btd:
     jobs:
@@ -189,7 +323,7 @@ jobs:
     executor:
       name: win/default
       shell: bash.exe
-      
+
     steps:
       - run:
           name: Install OpenVPN
@@ -197,39 +331,52 @@ jobs:
           command: |
             Invoke-WebRequest -Uri "https://swupdate.openvpn.org/community/releases/OpenVPN-2.5.2-I601-amd64.msi" -OutFile "OpenVPN-2.5.2-I601-amd64.msi"
             msiexec /i OpenVPN-2.5.2-I601-amd64.msi /qn
-            
+
       - run:
           name: Check IP before VPN connection
-          command: echo "Public IP before VPN connection is $(curl checkip.amazonaws.com)"
-          
+          command: echo "Public IP before VPN connection is $(curl -s https://checkip.amazonaws.com/)"
+
       - run:
           name: VPN Setup
-          command: |<br>            <span>echo $VPN_CLIENT_CONFIG | base64 --decode &gt; /C/PROGRA~1/OpenVPN/config/config.ovpn</span>
-
-            if grep auth-user-pass "/C/PROGRA~1/OpenVPN/config/config.ovpn"; then<br>              if [ -z "${VPN_USER:-}" ] || [ -z "${VPN_PASSWORD:-}" ]; then<br>                echo "Your VPN client is configured with a user-locked profile. Make sure to set the VPN_USER and VPN_PASSWORD environment variables"<br>                exit 1<br>              else<br>                printf "$VPN_USER\\n$VPN_PASSWORD" &gt; /C/PROGRA~1/OpenVPN/config/vpn.login<br>                sed -i 's|^auth-user-pass.*|auth-user-pass vpn\.login|' /C/PROGRA~1/OpenVPN/config/config.ovpn<br>              fi<br>            fi
-            
-            phone_home=$(netstat -an | grep ':22 .*ESTABLISHED' | head -n1 | awk '{ split($3, a, ":"); print a[1] }')
-            echo -e "\nroute $phone_home 255.255.255.255 net_gateway" | tee -a "/C/PROGRA~1/OpenVPN/config/config.ovpn"<br>            echo "route 169.254.0.0 255.255.0.0 net_gateway" | tee -a "/C/PROGRA~1/OpenVPN/config/config.ovpn"<br>            <br>            #Create and start the OpenVPN service<br><span>            sc.exe create "OpenVPN" binPath= "C:\PROGRA~1\OpenVPN\bin\openvpnserv.exe"</span><br>            <span>net start "OpenVPN"</span>
-        
-            
-      - run:
-          name: Wait for the connection to be established and check
           command: |
-            while [ $(cat <span>/C/PROGRA~1/OpenVPN/log/config.log</span>|grep -c "Initialization Sequence Completed") == 0 ]; do
-              echo "Attempting to connect..."
-              sleep 1;
+            echo $VPN_CLIENT_CONFIG | base64 --decode &gt; /C/PROGRA~1/OpenVPN/config/config.ovpn
+
+            if grep auth-user-pass "/C/PROGRA~1/OpenVPN/config/config.ovpn"; then
+              if [ -z "${VPN_USER:-}" ] || [ -z "${VPN_PASSWORD:-}" ]; then
+                echo "Your VPN client is configured with a user-locked profile. Make sure to set the VPN_USER and VPN_PASSWORD environment variables"
+                exit 1
+              else
+                printf "$VPN_USER\\n$VPN_PASSWORD" &gt; /C/PROGRA~1/OpenVPN/config/vpn.login
+                sed -i 's|^auth-user-pass.*|auth-user-pass vpn\.login|' /C/PROGRA~1/OpenVPN/config/config.ovpn
+              fi
+            fi
+
+            phone_home=$(netstat -an | grep ':22 .*ESTABLISHED' | head -n1 | awk '{ split($3, a, ":"); print a[1] }')
+            echo -e "\nroute $phone_home 255.255.255.255 net_gateway" | tee -a "/C/PROGRA~1/OpenVPN/config/config.ovpn"
+            echo "route 169.254.0.0 255.255.0.0 net_gateway" | tee -a "/C/PROGRA~1/OpenVPN/config/config.ovpn"
+
+            #Create and start the OpenVPN service
+            sc.exe create "OpenVPN" binPath= "C:\PROGRA~1\OpenVPN\bin\openvpnserv.exe"
+            net start "OpenVPN"
+
+      - run:
+          name: Wait for VPN connection to be established
+          command: |
+            while ! grep -c "Initialization Sequence Completed" /C/PROGRA~1/OpenVPN/log/config.log; do
+            echo "Waiting for connection..."
+              sleep 1
             done
             echo "VPN Connected"
-            echo "Public IP is now $(curl checkip.amazonaws.com)"
+            echo "Public IP is now $(curl -s https://checkip.amazonaws.com/)"
 
       - run:
           name: Run commands in our infrastructure
           command: |
             # A command
             # Another command
-            
+
       - run:
           name: Disconnect from OpenVPN
-          command: <span>net stop "OpenVPN"</span>
+          command: net stop "OpenVPN"
           when: always
 </pre>


### PR DESCRIPTION
I started this PR to make some minor improvements to the example code. After reviewing the HTML I found there was a lot going on.

- Remove [useless use of cat](https://en.wikipedia.org/wiki/Cat_(Unix)#Useless_use_of_cat) in a few places
- Remove unneeded `<span>` tags in HTML.
- Add `-s` flag to curl commands to have clean output
- Use `curl` everywhere instead of mixing `wget` and `curl`
- Use `apt-get` over `apt` as the API is considered stable where `apt` is meant for interactive terminals with a human at the other end.