### PR TITLE
Create workflow to trigger zkb-sync build on merge

### DIFF
--- a/.github/workflows/notify-zkb-sync-merge.yml
+++ b/.github/workflows/notify-zkb-sync-merge.yml
@@ -1,0 +1,18 @@
+name: Submodule Update Notifications
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  notify-zkb-sync:
+    name: Article update notification
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repositiory Dispatch
+        uses: peter-evans/repository-dispatch@v2.0.0
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # Need access to secrets to add token
+          repository: circleci/zkb-sync
+          event-type: article-edit-merged


### PR DESCRIPTION
Using repository dispatch to send an event to zkb-sync which will trigger another GitHub actions workflow to start a build in CircleCI. **This file will need a personal access token from GH secrets to be added (Owner access) before it can be merged.**