### PR TITLE
Create trigger-build-on-edit-approval.yml

### DIFF
--- a/.github/workflows/trigger-build-on-edit-approval.yml
+++ b/.github/workflows/trigger-build-on-edit-approval.yml
@@ -1,0 +1,18 @@
+name: Submodule Update Notifications (Approval)
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  notify-zkb-sync:
+    name: Article update notification
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repositiory Dispatch
+        uses: peter-evans/repository-dispatch@v2.0.0
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # Need access to secrets to add token
+          repository: circleci/zkb-sync
+          event-type: article-edit-approved


### PR DESCRIPTION
Created workflow to trigger a build on zkb-sync with event "article-edit-approved". **Requires access token before this file can be merged.**