### PR TITLE
Updated Github and Bitbucket integration links

### DIFF
--- a/data/articles/html/360018860473-How-to-push-a-commit-back-to-the-same-repository-as-part-of-the-CircleCI-job_en-us.html
+++ b/data/articles/html/360018860473-How-to-push-a-commit-back-to-the-same-repository-as-part-of-the-CircleCI-job_en-us.html
@@ -6,7 +6,7 @@
 <pre style="background-color: #f3f3f3;">  https://app.circleci.com/settings/project/[your vcs-type]/[your org-name]/[your project-name]/ssh<a href="https://circleci.com/:vcs-type/:org-name/:project-name/edit#checkout"> </a>
 </pre>
 <p>and click on the "Authorize with GitHub" button.</p>
-<p>1b) If you wish to use a read-write deployment key, follow the steps here to create it and configure the project so that the key has write permissions for it: <a href="https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-github-user-key">https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-github-user-key</a> or <a href="https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-bitbucket-user-key">https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-bitbucket-user-key</a> for Bitbucket users</p>
+<p>1b) If you wish to use a read-write deployment key, follow the steps here to create it and configure the project so that the key has write permissions for it: <a href="https://circleci.com/docs/github-integration">https://circleci.com/docs/github-integration</a> or <a href="https://circleci.com/docs/bitbucket-integration">https://circleci.com/docs/bitbucket-integration</a> for Bitbucket users</p>
 <p> </p>
 <h2>Common Issues:</h2>
 <p>1) "*** Please tell me who you are." error message upon running "git commit"</p>


### PR DESCRIPTION
Links for both Github and Bitbucket were pointing to Github integration. Have updated them accordingly.