### PR TITLE
Fix GitHub organization members link

### DIFF
--- a/data/articles/html/360034990033-Am-I-an-organization-admin-_en-us.html
+++ b/data/articles/html/360034990033-Am-I-an-organization-admin-_en-us.html
@@ -2,7 +2,7 @@
 <p>CircleCI mirrors permissions from your VCS provider. Meaning, if a user is an organization admin your VCS, they are an organization admin on CircleCI.  Permissions are checked against the VCS for each page load.</p>
 <h2>How to determine if you are an organization admin</h2>
 <h2>GitHub</h2>
-<p>An org admin is an <strong>Owner</strong> on Github and following at least one repo being built on CircleCI. You can view organization members by navigating to <a href="https://bitbucket.org/henna-test/workspace/members/">https://github.com/orgs/{YOUR_ORG_NAME}/people</a></p>
+<p>An org admin is an <strong>Owner</strong> on Github and following at least one repo being built on CircleCI. You can view organization members by navigating to <a href="https://github.com/orgs/%7BYOUR_ORG_NAME%7D/people">https://github.com/orgs/{YOUR_ORG_NAME}/people</a></p>
 <p><img src="https://support.circleci.com/hc/article_attachments/360044700594" alt="Screen_Shot_2019-08-27_at_9.46.17_AM.png"></p>
 <p> You can read more about GitHub Permissions here (<a href="https://help.github.com/en/articles/permission-levels-for-an-organization">https://help.github.com/en/articles/permission-levels-for-an-organization</a>)</p>
 <p> </p>


### PR DESCRIPTION
Link was incorrectly pointing at BitBucket instead of GitHub like the text implies.