### PR TITLE
Fix macos orb reference

### DIFF
--- a/data/articles/html/17402023738651-Installing-Rosetta-on-Apple-Silicon--M1-executors_en-us.html
+++ b/data/articles/html/17402023738651-Installing-Rosetta-on-Apple-Silicon--M1-executors_en-us.html
@@ -2,7 +2,7 @@
 <h2>Installing Rosetta</h2>
 <p><strong>Rosetta</strong> can be installed using CircleCI's <strong>macOS orb</strong>.</p>
 <pre style="background-color: #f3f3f3;" data-darkreader-inline-bgcolor=""><code>orbs:
-  macos: circle/macos@2.3.6
+  macos: circleci/macos@2.4.0
   
 jobs:
   build:


### PR DESCRIPTION
The name of the orb is not correct in the doc, which leads to an error if just copied and used, as I discovered while doing just that.

I also updated the version to the latest as why not.