### PR TITLE
Fix macOS orb name for M1 Rosetta instructions

### DIFF
--- a/data/articles/html/17402023738651-Installing-Rosetta-on-Apple-Silicon--M1-executors_en-us.html
+++ b/data/articles/html/17402023738651-Installing-Rosetta-on-Apple-Silicon--M1-executors_en-us.html
@@ -2,7 +2,7 @@
 <h2>Installing Rosetta</h2>
 <p><strong>Rosetta</strong> can be installed using CircleCI's <strong>macOS orb</strong>.</p>
 <pre style="background-color: #f3f3f3;" data-darkreader-inline-bgcolor=""><code>orbs:
-  macos: circle/macos@2.3.6
+  macos: circleci/macos@2.4.0
   
 jobs:
   build:


### PR DESCRIPTION
#### Description
17402023738651-Installing-Rosetta-on-Apple-Silicon--M1-executors_en-us.html has instructions for installing rosetta on an M1 executor but has the incorrect macOS orb name. The name given in the article is `circle/macOS@2.3.6` but it should be `circleci/macOS@2.3.6`. 

I also updated the orb version to the latest (2.4.0).