### PR TITLE
Avoid SIGPIPE (error 141) in auto-cancel Run Step example

### DIFF
--- a/data/articles/html/360055901372-AutoCancel-ReRun-if-Newer-Commit-Exists_en-us.html
+++ b/data/articles/html/360055901372-AutoCancel-ReRun-if-Newer-Commit-Exists_en-us.html
@@ -3,9 +3,9 @@
 <pre style="background-color: #f3f3f3;">- run:
     name: Check last commit to this commit
     command: |
-      LATEST_COMMIT=$(git ls-remote $CIRCLE_REPOSITORY_URL | grep $CIRCLE_BRANCH | cut -f 1)
-      LAST_COMMIT_DATETIME=$(git show --format="%ct" $LATEST_COMMIT | head -n 1)
-      BUILD_COMMIT_DATETIME=$(git show --format="%ct" $CIRCLE_SHA1 | head -n 1)
+      LATEST_COMMIT=$(git ls-remote --heads $CIRCLE_REPOSITORY_URL $CIRCLE_BRANCH | cut -f 1)
+      LAST_COMMIT_DATETIME=$(git show --format="%ct" --no-patch $LATEST_COMMIT)
+      BUILD_COMMIT_DATETIME=$(git show --format="%ct" --no-patch $CIRCLE_SHA1)
       if [ "$LAST_COMMIT_DATETIME" -gt "$BUILD_COMMIT_DATETIME" ]; then
         echo "more recent commit to branch, exiting"
         exit 1


### PR DESCRIPTION
The example shown at https://support.circleci.com/hc/en-us/articles/360055901372-Auto-Cancel-Re-Run-if-Newer-Commit-Exists is susceptible to SIGPIPE (Bash exit code 141) errors because of the mixture of commands. In short, use of `head -n 1` exits before the `git show` command ends, because `git show` is still busy outputting the diff of a given commit. This also created a race condition where shorter diffs would not trigger the issue but longer ones would.

This is solved with the changes in this PR, by not outputting the patches.

This also cleans up the first "latest commit" command by simplifying it to avoid needing grep, and also only focussing on `--heads` rather than potentially tags as well.